### PR TITLE
Fix code scanning alert no. 104: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "multer": "1.4.5-lts.1",
     "nodemailer": "^6.9.15",
     "session-file-store": "^1.5.0",
-    "sharp": "^0.33.5"
+    "sharp": "^0.33.5",
+    "express-rate-limit": "^7.4.0"
   },
   "keywords": [],
   "author": "",

--- a/routes/apiRoutes.js
+++ b/routes/apiRoutes.js
@@ -7,6 +7,13 @@ const fs = require("fs");
 const enmap = require("enmap");
 const database = require("../functions/eventsdb.js");
 const events = new enmap({ name: "events" });
+const rateLimit = require("express-rate-limit");
+
+// Set up rate limiter: maximum of 100 requests per 15 minutes
+const limiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // max 100 requests per windowMs
+});
 
 //* Almacenamiento de imágenes de los eventos, usamos Multer para poder gestionar las imágenes
 const storage = multer.diskStorage({
@@ -21,7 +28,7 @@ const storage = multer.diskStorage({
 const upload = multer({ storage });
 
 //* Ruta para subir la imagen del evento
-router.post("/upload", upload.single("thumbnailfile"), async (req, res) => {
+router.post("/upload", limiter, upload.single("thumbnailfile"), async (req, res) => {
   try {
     const fileName = req.file.filename;
     const filePath = path.join("uploads", fileName);


### PR DESCRIPTION
Fixes [https://github.com/AlexDeveloperUwU/liberteis/security/code-scanning/104](https://github.com/AlexDeveloperUwU/liberteis/security/code-scanning/104)

To fix the issue, we will use the `express-rate-limit` package to limit the number of requests to the `/upload` route. This will help prevent potential DoS attacks by ensuring that clients cannot overwhelm the server with too many requests in a short period.

1. Install the `express-rate-limit` package if it is not already installed.
2. Import the `express-rate-limit` package in the `routes/apiRoutes.js` file.
3. Set up a rate limiter with appropriate configuration (e.g., a maximum of 100 requests per 15 minutes).
4. Apply the rate limiter to the `/upload` route.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
