### PR TITLE
Fix code scanning alert no. 101: Missing CSRF middleware

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ const i18n = require("i18n");
 const fs = require("fs");
 const path = require("path");
 const FileStore = require("session-file-store")(session);
+const lusca = require("lusca");
 
 // Rutas del server
 const { logRequests } = require("./functions/logrequests.js");
@@ -62,6 +63,7 @@ app.use(
 // Inicialización de cookieParser e i18n
 app.use(cookieParser());
 app.use(i18n.init);
+app.use(lusca.csrf());
 
 // Middleware para establecer el idioma según la cookie o el parámetro de consulta
 app.use((req, res, next) => {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "multer": "1.4.5-lts.1",
     "nodemailer": "^6.9.15",
     "session-file-store": "^1.5.0",
-    "sharp": "^0.33.5"
+    "sharp": "^0.33.5",
+    "lusca": "^1.7.0"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
Fixes [https://github.com/AlexDeveloperUwU/liberteis/security/code-scanning/101](https://github.com/AlexDeveloperUwU/liberteis/security/code-scanning/101)

To fix the problem, we need to add CSRF protection middleware to the Express application. The `lusca` library is a well-known middleware for this purpose. We will install the `lusca` package and then configure it in the Express application. Specifically, we will add the CSRF middleware after the session middleware to ensure that all state-changing requests are protected.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
