### PR TITLE
Potential fix for code scanning alert no. 105: Use of password hash with insufficient computational effort

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "pino-http": "^10.4.0",
     "pino-http-print": "^3.1.0",
     "pino-pretty": "^13.0.0",
-    "thread-stream": "^3.1.0"
+    "thread-stream": "^3.1.0",
+    "bcrypt": "^5.1.1"
   },
   "devDependencies": {
     "@types/jest": "^29.5.14",

--- a/utils/dataSecurity.js
+++ b/utils/dataSecurity.js
@@ -31,16 +31,17 @@ function setKey() {
 }
 
 //! Functions for encrypting passwords (it doesn't decrypt)
+import bcrypt from "bcrypt";
+
 export function encryptPass(pass) {
-  const key = getKey();
-  const hmac = crypto.createHmac("sha256", key);
-  hmac.update(pass);
-  const hashedPassword = hmac.digest("hex");
+  const saltRounds = 10;
+  const salt = bcrypt.genSaltSync(saltRounds);
+  const hashedPassword = bcrypt.hashSync(pass, salt);
   return hashedPassword;
 }
 
 export function validatePass(pass, hash) {
-  return encryptPass(pass) === hash;
+  return bcrypt.compareSync(pass, hash);
 }
 
 //! Functions for encrypting and decrypting data


### PR DESCRIPTION
Potential fix for [https://github.com/AlexDeveloperUwU/liberteis/security/code-scanning/105](https://github.com/AlexDeveloperUwU/liberteis/security/code-scanning/105)

To fix the problem, we need to replace the current password hashing scheme with a more secure one, such as `bcrypt`. This will ensure that the password hashing process is computationally intensive and resistant to brute-force attacks.

- Replace the `encryptPass` function in `utils/dataSecurity.js` to use `bcrypt` for hashing passwords.
- Update the `validatePass` function to use `bcrypt` for comparing passwords.
- Add the necessary import for `bcrypt`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
